### PR TITLE
Wrong place signature logic fix

### DIFF
--- a/lib/engine.go
+++ b/lib/engine.go
@@ -129,6 +129,8 @@ func (e *GtwEngine) Score(guess string) (string, int) {
 	// and score any letter that still exists in the goal as
 	// an out-of-place letter.
 
+	unsolvedLetterCounts := make(map[rune]int)
+
 	nCorrect := 0
 	for i, g := range(aGuess) {
 		if g == aGoal[i] {
@@ -136,15 +138,23 @@ func (e *GtwEngine) Score(guess string) (string, int) {
 			aGoal[i] = 0
 			signature[i] = LETTER_CORRECT
 			nCorrect++
+		} else {
+			count, exists := unsolvedLetterCounts[aGoal[i]]
+
+			if !exists {
+				count = 0
+			}
+
+			unsolvedLetterCounts[aGoal[i]] = count + 1
 		}
 	}
 
 	for i, g := range(aGuess) {
 		if aGuess[i] != 0 {
-			for _, m := range(aGoal) {
-				if g == m {
-					signature[i] = LETTER_IN_WORD				
-				}
+			count, exists := unsolvedLetterCounts[g]
+			if exists && count > 0 {
+				unsolvedLetterCounts[g] = count - 1
+				signature[i] = LETTER_IN_WORD
 			}
 		}
 	}

--- a/lib/engine_test.go
+++ b/lib/engine_test.go
@@ -135,6 +135,15 @@ func TestScore(t *testing.T) {
 	}
 }
 
+func TestScoreOnlyFirstTwoTeesInWrongPlace(t *testing.T) {
+	engine := New([]string{"twist"})
+	engine.NewFixedGame("twist")
+	signature, score := engine.Score("ottto")
+	if signature != "#**##" || score != 0 {
+		t.Error("wrong signature or score for ottto", signature, score, engine.Cheat())
+	}
+}
+
 func TestFixedGame(t *testing.T) {
 	engine := New(loadTestCorpus(t))
 	aWord := engine.Corpus()[0]


### PR DESCRIPTION
Before this PR:

A guess of `"ottto"` for a goal of `"twist"` would report `"#***#"` (suggesting three `t`s in the wrong place).

After this PR:

A guess of `"ottto"` for a goal of `"twist"` would report `"#**##"` (suggesting two `t`s in the wrong place).
